### PR TITLE
test cases OSP Library added (solve ODE, Sensitivities)

### DIFF
--- a/test/tests_OSPLib/AreEqualWithinRelativeTolerance.m
+++ b/test/tests_OSPLib/AreEqualWithinRelativeTolerance.m
@@ -1,0 +1,13 @@
+function success = AreEqualWithinRelativeTolerance(y1, y2, relTol)
+    success = 0;
+    
+    if length(y1) ~= length(y2)
+        return;
+    end
+    
+    compare1 = abs(y1-y2) <= abs(y1)*relTol;
+    compare2 = abs(y1-y2) <= abs(y2)*relTol;
+    
+    compare = compare1 & compare2;
+    
+    success = all(compare);

--- a/test/tests_OSPLib/UAT_TC_001_OSPLib_01_SPM_RE/SimModel4_ExampleInput06.xml
+++ b/test/tests_OSPLib/UAT_TC_001_OSPLib_01_SPM_RE/SimModel4_ExampleInput06.xml
@@ -1,0 +1,207 @@
+<Simulation objectPathDelimiter="/" xmlns="http://www.systems-biology.com">
+	<EventList/>
+	<VariableList>
+		<V id="1" name="y1" path="TopContainer" unit="L" initialValueFormulaId="10" entityId="y1">
+			<ScaleFactor>1</ScaleFactor>
+			<RHSFormulaList>
+				<RHSFormula id="11"/>
+				<RHSFormula id="12"/>
+				<RHSFormula id="13"/>
+			</RHSFormulaList>
+		</V>
+		<V id="2" name="y2" path="TopContainer" unit="L" initialValueFormulaId="20" entityId="y2">
+			<ScaleFactor>1</ScaleFactor>
+			<RHSFormulaList>
+				<RHSFormula id="21"/>
+				<RHSFormula id="22"/>
+			</RHSFormulaList>
+		</V>
+		<V id="3" name="y3" path="TopContainer" unit="L" initialValueFormulaId="30" entityId="y3">
+			<ScaleFactor>1</ScaleFactor>
+			<RHSFormulaList>
+				<RHSFormula id="31"/>
+				<RHSFormula id="32"/>
+			</RHSFormulaList>
+		</V>
+	</VariableList>
+	<ObserverList>
+		<Observer id="300" entityId="Obs1" name="Obs1" path="TopContainer" unit="" formulaId="3000"/>
+	</ObserverList>	
+	<ParameterList>
+		<P id="111" name="P1" path="TopContainer" unit="L" formulaId="1110" canBeVaried="1" entityId="P1"/>
+		<P id="112" name="P2" path="TopContainer" unit="L" formulaId="1120" canBeVaried="1" entityId="P2"/>
+		<P id="113" name="P3" path="TopContainer" unit="L" formulaId="1130" canBeVaried="1" entityId="P3"/>
+		<P id="114" name="P4" path="TopContainer" unit="L" formulaId="1140" canBeVaried="1" entityId="P4"/>
+		<P id="80" name="AbsTol" path="No" unit="" formulaId="90" canBeVaried="1" entityId="AbsTol"/>
+		<P id="81" name="RelTol" path="No" unit="" formulaId="91" canBeVaried="1" entityId="RelTol"/>
+		<P id="82" name="H0" path="No" unit="" formulaId="92" canBeVaried="1" entityId="H0"/>
+		<P id="83" name="HMin" path="No" unit="" formulaId="93" canBeVaried="1" entityId="HMin"/>
+		<P id="84" name="HMax" path="No" unit="" formulaId="94" canBeVaried="1" entityId="HMax"/>
+		<P id="85" name="MXStep" path="No" unit="" formulaId="95" canBeVaried="1" entityId="MXStep"/>
+		<P id="86" name="UseJacobian" path="No" unit="" formulaId="96" canBeVaried="1" entityId="UseJacobian"/>
+	</ParameterList>
+	<FormulaList>
+		<ExplicitFormula id="3000">
+			<Equation>2*y1</Equation>
+			<ParameterList></ParameterList>
+			<VariableList>
+				<V alias="y1" id="1"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="10">
+			<Equation>2</Equation>
+			<ParameterList></ParameterList>
+			<VariableList></VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="20">
+			<Equation>P1+P2-1</Equation>
+			<ParameterList>
+				<P alias="P1" id="111"/>
+				<P alias="P2" id="112"/>
+			</ParameterList>
+			<VariableList></VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="30">
+			<Equation>y1</Equation>
+			<ParameterList></ParameterList>
+			<VariableList>
+				<V alias="y1" id="1"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="1110">
+			<Equation>sin(y3)^2</Equation>
+			<ParameterList></ParameterList>
+			<VariableList>
+				<V alias="y3" id="3"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="1120">
+			<Equation>cos(y3)^2</Equation>
+			<ParameterList></ParameterList>
+			<VariableList>
+				<V alias="y3" id="3"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="1130">
+			<Equation>Time</Equation>
+			<ParameterList>
+				<P alias="Time" id="0"/>
+			</ParameterList>
+			<VariableList></VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="1140">
+			<Equation>y3-2</Equation>
+			<ParameterList></ParameterList>
+			<VariableList>
+				<V alias="y3" id="3"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="11">
+			<Equation>(P1+P2)*y2</Equation>
+			<ParameterList>
+				<P alias="P1" id="111"/>
+				<P alias="P2" id="112"/>
+			</ParameterList>
+			<VariableList>
+				<V alias="y2" id="2"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="12">
+			<Equation>(P3-Time)*y1</Equation>
+			<ParameterList>
+				<P alias="P3" id="113"/>
+				<P alias="Time" id="0"/>
+			</ParameterList>
+			<VariableList>
+				<V alias="y1" id="1"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="13">
+			<Equation>y3-2</Equation>
+			<ParameterList></ParameterList>
+			<VariableList>
+				<V alias="y3" id="3"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="21">
+			<Equation>y1</Equation>
+			<ParameterList></ParameterList>
+			<VariableList>
+				<V alias="y1" id="1"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="22">
+			<Equation>P4</Equation>
+			<ParameterList>
+				<P alias="P4" id="114"/>
+			</ParameterList>
+			<VariableList></VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="31">
+			<Equation>0</Equation>
+			<ParameterList></ParameterList>
+			<VariableList></VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="32">
+			<Equation>0</Equation>
+			<ParameterList></ParameterList>
+			<VariableList></VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="90">
+			<Equation>1E-12</Equation>
+			<ParameterList/>
+			<VariableList/>
+		</ExplicitFormula>
+		<ExplicitFormula id="91">
+			<Equation>1E-09</Equation>
+			<ParameterList/>
+			<VariableList/>
+		</ExplicitFormula>
+		<ExplicitFormula id="92">
+			<Equation>1E-10</Equation>
+			<ParameterList/>
+			<VariableList/>
+		</ExplicitFormula>
+		<ExplicitFormula id="93">
+			<Equation>0</Equation>
+			<ParameterList/>
+			<VariableList/>
+		</ExplicitFormula>
+		<ExplicitFormula id="94">
+			<Equation>60</Equation>
+			<ParameterList/>
+			<VariableList/>
+		</ExplicitFormula>
+		<ExplicitFormula id="95">
+			<Equation>100000</Equation>
+			<ParameterList/>
+			<VariableList/>
+		</ExplicitFormula>
+		<ExplicitFormula id="96">
+			<Equation>1</Equation>
+			<ParameterList/>
+			<VariableList/>
+		</ExplicitFormula>
+	</FormulaList>
+	<Solver name="CVODE_1.0">
+		<H0 id="82"/>
+		<HMax id="84"/>
+		<HMin id="83"/>
+		<AbsTol id="80"/>
+		<MxStep id="85"/>
+		<RelTol id="81"/>
+		<UseJacobian id="86"/>
+	</Solver>
+	<OutputSchema>
+		<OutputIntervalList>
+			<OutputInterval distribution="Uniform">
+				<StartTime>0</StartTime>
+				<EndTime>10</EndTime>
+				<NumberOfTimePoints>11</NumberOfTimePoints>
+			</OutputInterval>
+		</OutputIntervalList>
+		<OutputTimeList>
+			<OutputTime>0</OutputTime>
+		</OutputTimeList>
+	</OutputSchema>
+</Simulation>

--- a/test/tests_OSPLib/UAT_TC_001_OSPLib_01_SPM_RE/testOSPLib_01.m
+++ b/test/tests_OSPLib/UAT_TC_001_OSPLib_01_SPM_RE/testOSPLib_01.m
@@ -1,5 +1,7 @@
 function success = testOSPLib_01(pathToReportingEngine, simulationFile)
 
+warning('off', 'MATLAB:mex:deprecatedExtension')
+
 success = 0;
 
 %setup environment

--- a/test/tests_OSPLib/UAT_TC_001_OSPLib_01_SPM_RE/testOSPLib_01.m
+++ b/test/tests_OSPLib/UAT_TC_001_OSPLib_01_SPM_RE/testOSPLib_01.m
@@ -1,0 +1,99 @@
+function success = testOSPLib_01(pathToReportingEngine, simulationFile)
+
+success = 0;
+
+%setup environment
+addpath(genpath(pathToReportingEngine));
+libPath = [pathToReportingEngine filesep 'lib'];
+setenv('path', [libPath ';' getenv('path')]);
+
+%Create the component
+comp=DCIMatlabR2013b6_0('LoadComponent', [libPath filesep 'OSPSuite_SimModelComp.xml']);
+
+%Get parameter table
+tab=DCIMatlabR2013b6_0('GetParameterTable',comp,1);
+
+%Simulation Schema
+tab.Variables(1).Values={[libPath filesep 'OSPSuite.SimModel.xsd']};
+
+%Simulation File
+tab.Variables(2).Values={simulationFile};
+
+%Set parameter table into the component and calculate
+DCIMatlabR2013b6_0('SetParameterTable',comp,1,tab);
+DCIMatlabR2013b6_0('Configure',comp);
+DCIMatlabR2013b6_0('ProcessMetaData',comp);
+DCIMatlabR2013b6_0('ProcessData',comp);
+
+%Get 1st Output table (Simulation Times)
+outTabTimes=DCIMatlabR2013b6_0('GetOutputTable',comp,1);
+
+%Get 2nd Output table (Simulation values)
+outTabValues=DCIMatlabR2013b6_0('GetOutputTable',comp,2);
+
+%set output time vector
+t = outTabTimes.Variables(1).Values;
+
+%set all system outputs (ode variables and observers)
+for i=1:length(outTabValues.Variables)
+    values(i).Name = outTabValues.Variables(i).Name;
+    values(i).Values = outTabValues.Variables(i).Values;
+end
+
+%================= verify model outputs =========================
+
+%relative tolerance for values comparison
+relTol = 1e-5;
+
+% output time vector must be equal to [0,1,2,3,4,5,6,7,8,9,10] within relative tolerance
+if ~AreEqualWithinRelativeTolerance(t, [0:10]', relTol)
+    error('output time vector does not match');
+end
+
+% Variable values must have length 4
+if length(values) ~= 4
+    error('number of model outputs does not match');
+end
+
+% values(1).Name equals to 'y1'
+if ~strcmp(values(1).Name, 'y1')
+    error('Name of the 1st output does not match y1');
+end
+
+% values(1).Values equals to exp(t)+exp(-t) within relative tolerance
+if ~AreEqualWithinRelativeTolerance(values(1).Values, exp(t)+exp(-t), relTol)
+    error('output time vector for y1 does not match');
+end
+
+% values(2).Name equals to 'y2'
+if ~strcmp(values(2).Name, 'y2')
+    error('Name of the 2nd output does not match y2');
+end
+
+% values(2).Values equals to exp(t)-exp(-t) within relative tolerance
+if ~AreEqualWithinRelativeTolerance(values(2).Values, exp(t)-exp(-t), relTol)
+    error('output time vector for y2 does not match');
+end
+
+% values(3).Name equals to 'y3'
+if ~strcmp(values(3).Name, 'y3')
+    error('Name of the 3rd output does not match y3');
+end
+
+% values(3).Values is constant value 2 within relative tolerance
+if ~AreEqualWithinRelativeTolerance(values(3).Values, 2, relTol)
+    error('output time vector for y3 does not match');
+end
+
+% values(4).Name equals to 'Obs1'
+if ~strcmp(values(4).Name, 'Obs1')
+    error('Name of the 4th output does not match Obs1');
+end
+
+% values(4).Values equals to 2* values(1).Values within relative tolerance
+if ~AreEqualWithinRelativeTolerance(values(4).Values, 2* values(1).Values, relTol)
+    error('output time vector does not match');
+end
+
+%all tests successfull
+success = 1;

--- a/test/tests_OSPLib/UAT_TC_002_OSPLib_02_SPM_RE/cvsRoberts_FSA_dns.xml
+++ b/test/tests_OSPLib/UAT_TC_002_OSPLib_02_SPM_RE/cvsRoberts_FSA_dns.xml
@@ -1,0 +1,101 @@
+<Simulation objectPathDelimiter="/" version="4" xmlns="http://www.systems-biology.com">
+	<EventList/>
+	<ObserverList>
+		<Observer id="4" entityId="Obs1" name="Obs1" path="TopContainer/SubContainer/Obs1" unit="" persistable="1" formulaId="41" />
+	</ObserverList>
+	<VariableList>
+		<V id="1" name="y1" path="TopContainer/SubContainer/y1" unit="L" value="1.0" entityId="y1">
+			<ScaleFactor>1</ScaleFactor>
+			<RHSFormulaList>
+				<RHSFormula id="11"/>
+			</RHSFormulaList>
+		</V>
+		<V id="2" name="y2" path="TopContainer/SubContainer/y2" unit="L" value="0" entityId="y2">
+			<ScaleFactor>1</ScaleFactor>
+			<RHSFormulaList>
+				<RHSFormula id="21"/>
+			</RHSFormulaList>
+		</V>
+		<V id="3" name="y3" path="TopContainer/SubContainer/y3" unit="L" value="0" entityId="y3">
+			<ScaleFactor>1</ScaleFactor>
+			<RHSFormulaList>
+				<RHSFormula id="31"/>
+			</RHSFormulaList>
+		</V>
+	</VariableList>
+	<ParameterList>
+		<P id="111" name="P1" path="TopContainer/SubContainer/P1" unit="L" value="0.04" canBeVaried="1" entityId="P1"/>
+		<P id="112" name="P2" path="TopContainer/SubContainer/P2" unit="L" value="1e4" canBeVaried="1" entityId="P2"/>
+		<P id="113" name="P3" path="TopContainer/SubContainer/P3" unit="L" value="3e7" canBeVaried="1" entityId="P3"/>
+		<P id="80" name="AbsTol" path="No" unit="" value="1E-14" canBeVaried="1" entityId="AbsTol"/>
+		<P id="81" name="RelTol" path="No" unit="" value="1E-4" canBeVaried="1" entityId="RelTol"/>
+		<P id="82" name="H0" path="No" unit="" value="0" canBeVaried="1" entityId="H0"/>
+		<P id="83" name="HMin" path="No" unit="" value="0" canBeVaried="1" entityId="HMin"/>
+		<P id="84" name="HMax" path="No" unit="" value="60" canBeVaried="1" entityId="HMax"/>
+		<P id="85" name="MXStep" path="No" unit="" value="100000" canBeVaried="1" entityId="MXStep"/>
+		<P id="86" name="UseJacobian" path="No" unit="" value="1" canBeVaried="1" entityId="UseJacobian"/>
+	</ParameterList>
+	<FormulaList>
+		<ExplicitFormula id="11">
+			<Equation>-p1*y1 + p2*y2*y3</Equation>
+			<ParameterList>
+				<P alias="p1" id="111"/>
+				<P alias="p2" id="112"/>
+			</ParameterList>
+			<VariableList>
+				<V alias="y1" id="1"/>
+				<V alias="y2" id="2"/>
+				<V alias="y3" id="3"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="21">
+			<Equation>p1*y1 - p2*y2*y3 - p3*(y2)^2</Equation>
+			<ParameterList>
+				<P alias="p1" id="111"/>
+				<P alias="p2" id="112"/>
+				<P alias="p3" id="113"/>
+			</ParameterList>
+			<VariableList>
+				<V alias="y1" id="1"/>
+				<V alias="y2" id="2"/>
+				<V alias="y3" id="3"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="31">
+			<Equation>p3*(y2)^2</Equation>
+			<ParameterList>
+				<P alias="p3" id="113"/>
+			</ParameterList>
+			<VariableList>
+				<V alias="y2" id="2"/>
+			</VariableList>
+		</ExplicitFormula>
+		<ExplicitFormula id="41">
+			<Equation>y1+2*y2+3*y3</Equation>
+			<ParameterList>
+			</ParameterList>
+			<VariableList>
+				<V alias="y1" id="1"/>
+				<V alias="y2" id="2"/>
+				<V alias="y3" id="3"/>
+			</VariableList>
+		</ExplicitFormula>
+	</FormulaList>
+	<Solver name="CVODES_2.8.2_1.0">
+		<H0 id="82"/>
+		<HMax id="84"/>
+		<HMin id="83"/>
+		<AbsTol id="80"/>
+		<MxStep id="85"/>
+		<RelTol id="81"/>
+		<UseJacobian id="86"/>
+	</Solver>
+	<OutputSchema>
+		<OutputIntervalList/>
+		<OutputTimeList>
+			<OutputTime>0</OutputTime>
+			<OutputTime>0.4</OutputTime>
+			<OutputTime>4</OutputTime>
+		</OutputTimeList>
+	</OutputSchema>
+</Simulation>

--- a/test/tests_OSPLib/UAT_TC_002_OSPLib_02_SPM_RE/testOSPLib_02.m
+++ b/test/tests_OSPLib/UAT_TC_002_OSPLib_02_SPM_RE/testOSPLib_02.m
@@ -1,0 +1,143 @@
+function success = testOSPLib_02(pathToReportingEngine, simulationFile)
+
+%ODE system used for test is taken from the CVODES example "A serial dense example: cvsRoberts_FSA_dns"
+%s. https://computation.llnl.gov/sites/default/files/public/cvs_examples.pdf
+
+success = 0;
+
+%setup environment
+addpath(genpath(pathToReportingEngine));
+libPath = [pathToReportingEngine filesep 'lib'];
+setenv('path', [libPath ';' getenv('path')]);
+
+%Create the component
+comp=DCIMatlabR2013b6_0('LoadComponent', [libPath filesep 'OSPSuite_SimModelComp.xml']);
+
+%Get parameter table
+tab=DCIMatlabR2013b6_0('GetParameterTable',comp,1);
+
+%Simulation Schema
+tab.Variables(1).Values={[libPath filesep 'OSPSuite.SimModel.xsd']};
+
+%Simulation File
+tab.Variables(2).Values={simulationFile};
+
+%Set parameter table into the component and calculate
+DCIMatlabR2013b6_0('SetParameterTable',comp,1,tab);
+DCIMatlabR2013b6_0('Configure',comp);
+
+%define column indices for input parameters tables (both all and variable)
+ParamIDIdx=1; ParamPathIdx=2; ParamValueIdx=3; ParamUnitIdx=4; ParamIsFormulaIdx=5; 
+ParamFormulaIdx=6; ParamDescriptionIdx=7; ParamIsVariableIdx=8; ParamCalculateSensitivityIdx=9;
+
+%get variable parameters table
+inTab2 = DCIMatlabR2013b6_0('GetInputTable',comp,2);
+
+%calculate sensitivity for parameters p1, p2, p3
+inTab2.Variables(ParamCalculateSensitivityIdx).Values(1:3)=[1 1 1];
+
+%Save input table into the component and set sensitivity parameters
+DCIMatlabR2013b6_0('SetInputTable',comp,2,inTab2);
+
+DCIMatlabR2013b6_0('ProcessMetaData',comp);
+DCIMatlabR2013b6_0('ProcessData',comp);
+
+%Get 1st Output table (Simulation Times)
+outTabTimes=DCIMatlabR2013b6_0('GetOutputTable',comp,1);
+
+%Get 2nd Output table (Simulation values)
+outTabValues=DCIMatlabR2013b6_0('GetOutputTable',comp,2);
+
+%Get 3rd Output table (parameter sensitivities)
+outTabSensitivities=DCIMatlabR2013b6_0('GetOutputTable',comp,3);
+
+%set output time vector
+t = outTabTimes.Variables(1).Values;
+
+%number of sensitivity vectors should be 12: d(y1,y2,y3,Obs1)/d(p1,p2,p3)
+if length(outTabSensitivities.Variables)~=12
+    error('not all expected sensitivities are calculated');
+end
+
+%get all sensitivities
+for i=1:length(outTabSensitivities.Variables)
+    sensitivities(i).OutputName = outTabSensitivities.Variables(i).Name;
+    sensitivities(i).Values = outTabSensitivities.Variables(i).Values;
+    sensitivities(i).SensitivityParameterId = outTabSensitivities.Variables(i).Attributes(5).Value;
+end
+
+%================= verify model outputs =========================
+
+%relative tolerance for values comparison
+relTol = 1e-3;
+
+% output time vector must be equal to [0 0.4 4] within relative tolerance
+if ~AreEqualWithinRelativeTolerance(t, [0 0.4 4]', relTol)
+    error('output time vector does not match');
+end
+
+%now check sensitivity values. 
+%Expected values are taken from the corresponding CVODES example cvsRoberts_FSA_dns (first 2 time steps )
+%s. https://computation.llnl.gov/sites/default/files/public/cvs_examples.pdf
+
+%dy1/dp1
+checkSensitivityValues(sensitivities(1), 'y1', '111', [0 -3.5595e-01 -1.8761e+00]', relTol);
+
+%dy1/dp2
+checkSensitivityValues(sensitivities(2), 'y1', '112', [0 9.5431e-08 2.9614e-06]', relTol);
+
+%dy1/dp3
+checkSensitivityValues(sensitivities(3), 'y1', '113', [0 -1.5833e-11 -4.9334e-10]', relTol);
+
+%dy2/dp1
+checkSensitivityValues(sensitivities(4), 'y2', '111', [0 3.9025e-04 1.7922e-04]', relTol);
+
+%dy2/dp2
+checkSensitivityValues(sensitivities(5), 'y2', '112', [0 -2.1309e-10 -5.8305e-10]', relTol);
+
+%dy2/dp3
+checkSensitivityValues(sensitivities(6), 'y2', '113', [0 -5.2900e-13 -2.7626e-13]', relTol);
+
+%dy3/dp1
+checkSensitivityValues(sensitivities(7), 'y3', '111', [0 3.5556e-01 1.8759e+00]', relTol);
+
+%dy3/dp2
+checkSensitivityValues(sensitivities(8), 'y3', '112', [0 -9.5218e-08 -2.9608e-06]', relTol);
+
+%dy3/dp3
+checkSensitivityValues(sensitivities(9), 'y3', '113', [0 1.6362e-11 4.9362e-10]', relTol);
+
+%observer Obs 1 is defined as y1+2*y2+3*y3
+%so the same formula must apply for its sensitivities
+
+dy1_dp1=sensitivities(1).Values; dy1_dp2=sensitivities(2).Values; dy1_dp3=sensitivities(3).Values;
+dy2_dp1=sensitivities(4).Values; dy2_dp2=sensitivities(5).Values; dy2_dp3=sensitivities(6).Values;
+dy3_dp1=sensitivities(7).Values; dy3_dp2=sensitivities(8).Values; dy3_dp3=sensitivities(9).Values;
+
+%dObs1/dp1
+checkSensitivityValues(sensitivities(10), 'Obs1', '111', [0 dy1_dp1(2)+2*dy2_dp1(2)+3*dy3_dp1(2) dy1_dp1(3)+2*dy2_dp1(3)+3*dy3_dp1(3)]', relTol);
+
+%dObs1/dp2
+checkSensitivityValues(sensitivities(11), 'Obs1', '112', [0 dy1_dp2(2)+2*dy2_dp2(2)+3*dy3_dp2(2) dy1_dp2(3)+2*dy2_dp2(3)+3*dy3_dp2(3)]', relTol);
+
+%dObs1/dp3
+checkSensitivityValues(sensitivities(12), 'Obs1', '113', [0 dy1_dp3(2)+2*dy2_dp3(2)+3*dy3_dp3(2) dy1_dp3(3)+2*dy2_dp3(3)+3*dy3_dp3(3)]', relTol);
+
+
+%all tests successfull
+success = 1;
+
+function checkSensitivityValues(sensitivity, expectedName, expectedSensitivityParameterId, expectedSensitivityValues, relTol)
+
+    if ~strcmp(sensitivity.OutputName, expectedName)
+        error(['Name of the output does not match ' expectedName]);
+    end
+    
+    if ~strcmp(sensitivity.SensitivityParameterId, expectedSensitivityParameterId)
+        error(['Sensitivity parameter id does not match ' expectedSensitivityParameterId]);
+    end
+    
+    if ~AreEqualWithinRelativeTolerance(sensitivity.Values, expectedSensitivityValues, relTol)
+        error(['Sensitivity values of ' expectedName ' do not match']);
+    end
+    

--- a/test/tests_OSPLib/UAT_TC_002_OSPLib_02_SPM_RE/testOSPLib_02.m
+++ b/test/tests_OSPLib/UAT_TC_002_OSPLib_02_SPM_RE/testOSPLib_02.m
@@ -1,5 +1,7 @@
 function success = testOSPLib_02(pathToReportingEngine, simulationFile)
 
+warning('off', 'MATLAB:mex:deprecatedExtension')
+
 %ODE system used for test is taken from the CVODES example "A serial dense example: cvsRoberts_FSA_dns"
 %s. https://computation.llnl.gov/sites/default/files/public/cvs_examples.pdf
 


### PR DESCRIPTION
# UAT_TC_001_OSPLib_01_SPM_RE
* Output time courses of the ODE state variables for models with known analytical solution must match this analytical solution within defined tolerance.
* Observers of a model should be calculated correctly

Test ODE model (described by the xml file _SimModel4_ExampleInput06.xml_) is defined as following:
```
y1' = (P1+P2)*y2 + (P3-Time)*y1 + (y3-2)
y2' = y1 + P4
y3' = 0 + 0

y1(0) = 2
y2(0) = P1 + P2 -1
y3(0) = y1

P1 = sin(y3)^2
P2 = cos(y3)^2
P3 = Time
P4 = y3 - 2
```
System is equivalent to:
```
y1' = y2 y1(0) = 2
y2' = y1 y2(0) = 0
y3' = 0 y3(0) = 2
```
Analytical solution is:
```
y1 = exp(Time) + exp(-Time)
y2 = exp(Time) - exp(-Time)
y3 = 2
```
Additionaly, an Observer Obs1 is defined as
`Obs1 = 2*y1`

# UAT_TC_002_OSPLib_02_SPM_RE
ODE System and expected sensitivities are taken from CVODES example cvRoberts_dns
(s. https://computation.llnl.gov/sites/default/files/public/cvs_examples.pdf)

Test ODE model is described by the xml file _cvsRoberts_FSA_dns.xml_).
Sensitivities for the first 2 time steps are compared with the CVODES example
<img width="368" alt="sensi" src="https://user-images.githubusercontent.com/25061876/29742433-73fbdbe4-8a7f-11e7-86db-93deea3a0def.png">
