### PR TITLE
allow empty entries in comparisonTimeProfile plots

### DIFF
--- a/src/code/qualification/plotQualificationComparisonTimeProfile.m
+++ b/src/code/qualification/plotQualificationComparisonTimeProfile.m
@@ -58,11 +58,15 @@ for i=1:length(Curves)
             'In Comparison Time Profile Plot %d, Mapping %d, Ouptut %s was not found', plotIndex, i, Curves{i}.Output);
         throw(ME);
     end
-    [p_handle_obs, legLabel_obs] = testandplotObservations(Curves{i}, ObservedDataSets, MW, xAxesOptions, yAxesOptions, yyAxesOptions);
-    if isempty(p_handle_obs)
-        ME = MException('plotQualificationComparisonTimeProfile:notFoundInPath', ...
-            'In Comparison Time Profile Plot %d, Mapping %d, ObservedData %s was not found', plotIndex, i, Curves{i}.ObservedData);
-        throw(ME);
+    if ~isempty(Curves{i}.ObservedData)
+        [p_handle_obs, legLabel_obs] = testandplotObservations(Curves{i}, ObservedDataSets, MW, xAxesOptions, yAxesOptions, yyAxesOptions);
+        if isempty(p_handle_obs)
+            ME = MException('plotQualificationComparisonTimeProfile:notFoundInPath', ...
+                'In Comparison Time Profile Plot %d, Mapping %d, ObservedData %s was not found', plotIndex, i, Curves{i}.ObservedData);
+            throw(ME);
+        end
+    else
+       legLabel_obs = {}; 
     end
     legendLabels=[legendLabels legLabel_sim legLabel_obs];
 end

--- a/src/code/qualification/plotQualificationDDIRatio.m
+++ b/src/code/qualification/plotQualificationDDIRatio.m
@@ -202,12 +202,20 @@ for i=1:length(DDIRatioGroups)
                 if isinf(DDIRatios(j).SimulationDDI.EndTime)
                     PKpredField(k).DDI = 'AUC_inf';
                 else
-                    PKpredField(k).DDI = 'AUC_last';
+                    if DDIRatios(j).SimulationDDI.EndTime > DDITime(end)
+                        PKpredField(k).DDI = 'AUC_inf';
+                    else
+                        PKpredField(k).DDI = 'AUC_last';
+                    end
                 end
                 if isinf(DDIRatios(j).SimulationControl.EndTime)
                     PKpredField(k).Control = 'AUC_inf';
                 else
-                    PKpredField(k).Control = 'AUC_last';
+                    if DDIRatios(j).SimulationControl.EndTime > ControlTime(end)
+                        PKpredField(k).Control = 'AUC_inf';
+                    else
+                        PKpredField(k).Control = 'AUC_last';
+                    end
                 end
             elseif strcmpi(PKParameter{k}, 'CMAX')
                 PKpredField(k).DDI = 'cMax';


### PR DESCRIPTION
via `"ObservedData": [] `
in  "ComparisonTimeProfilePlots"

Fixes #257 

@Yuri05 